### PR TITLE
Add VPC Flow Logs for Network Security

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@ The following people (in alphabetical order) have contributed to or reviewed thi
 * [Alexander Atallah (alexanderatallah)](https://github.com/alexanderatallah)
 * [Artem Nikitin (artemnikitin)](https://github.com/artemnikitin) — [2+](https://github.com/open-guides/og-aws/commits?author=artemnikitin)/[1+](https://github.com/open-guides/og-aws/issues?q=author%3Aartemnikitin)
 * [Ben Kehoe (benkehoe)](https://github.com/benkehoe) — [4+](https://github.com/open-guides/og-aws/commits?author=benkehoe)/[1+](https://github.com/open-guides/og-aws/issues?q=author%3Abenkehoe)
+* [Bo Bayles (bbayles)](https://github.com/bbayles)
 * [Adam Mathias Bittlingmayer (bittlingmayer)](https://github.com/bittlingmayer)
 * [Donne Martin (donnemartin)](https://github.com/donnemartin)
 * [Max Grigorev (forwidur)](https://github.com/forwidur)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,7 +8,6 @@ The following people (in alphabetical order) have contributed to or reviewed thi
 * [Alexander Atallah (alexanderatallah)](https://github.com/alexanderatallah)
 * [Artem Nikitin (artemnikitin)](https://github.com/artemnikitin) — [2+](https://github.com/open-guides/og-aws/commits?author=artemnikitin)/[1+](https://github.com/open-guides/og-aws/issues?q=author%3Aartemnikitin)
 * [Ben Kehoe (benkehoe)](https://github.com/benkehoe) — [4+](https://github.com/open-guides/og-aws/commits?author=benkehoe)/[1+](https://github.com/open-guides/og-aws/issues?q=author%3Abenkehoe)
-* [Bo Bayles (bbayles)](https://github.com/bbayles)
 * [Adam Mathias Bittlingmayer (bittlingmayer)](https://github.com/bittlingmayer)
 * [Donne Martin (donnemartin)](https://github.com/donnemartin)
 * [Max Grigorev (forwidur)](https://github.com/forwidur)

--- a/README.md
+++ b/README.md
@@ -1106,7 +1106,7 @@ VPCs, Network Security, and Security Groups
 	-	You expose a smaller surface area for attack compared to exposing separate (potentially authenticated) services over the public internet.
 		-	e.g. A bug in the YAML parser used by the Ruby on Rails admin site is much less serious when the admin site is only visible to the private network and accessed through VPN.
 	-	Another common pattern (especially as deployments get larger, security or regulatory requirements get more stringent, or team sizes increase) is to provide a [bastion host](https://www.pandastrike.com/posts/20141113-bastion-hosts) behind a VPN through which all SSH connections need to transit.
--   **VPC Flow Logs** allow you to monitor the network traffic to, from, and within your VPC. Logs are stored in CloudWatch Logs groups, and can be used for security monitoring (with 3rd party tools), performance evaluation, and forensic investigation.
+-   **VPC Flow Logs** allow you to monitor the network traffic to, from, and within your VPC. Logs are stored in CloudWatch Logs groups, and can be used for security monitoring (with third party tools), performance evaluation, and forensic investigation.
     -	See the [VPC Flow Logs User Guide](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) for basic information.
     -	See the [flowlogs-reader](https://github.com/obsrvbl/flowlogs-reader) CLI tool and Python library to retrieve and work with VPC Flow Logs.
     -	Services like [Observable Networks](https://observable.net/) and [Sumo Logic](https://www.sumologic.com/) can use VPC Flow Logs as input for security monitoring and/or searching.

--- a/README.md
+++ b/README.md
@@ -1106,6 +1106,9 @@ VPCs, Network Security, and Security Groups
 	-	You expose a smaller surface area for attack compared to exposing separate (potentially authenticated) services over the public internet.
 		-	e.g. A bug in the YAML parser used by the Ruby on Rails admin site is much less serious when the admin site is only visible to the private network and accessed through VPN.
 	-	Another common pattern (especially as deployments get larger, security or regulatory requirements get more stringent, or team sizes increase) is to provide a [bastion host](https://www.pandastrike.com/posts/20141113-bastion-hosts) behind a VPN through which all SSH connections need to transit.
+-   **VPC Flow Logs** allow you to monitor the network traffic to, from, and within your VPC. Logs are stored in CloudWatch Logs groups, and can be used for security monitoring (with 3rd party tools), performance evaluation, and forensic investigation.
+    -	See the [VPC Flow Logs User Guide](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) for basic information.
+    -	See the [flowlogs-reader](https://github.com/obsrvbl/flowlogs-reader) CLI tool and Python library to retrieve and work with VPC Flow Logs.
 
 ### VPC and Network Security Gotchas and Limitations
 

--- a/README.md
+++ b/README.md
@@ -1109,7 +1109,6 @@ VPCs, Network Security, and Security Groups
 -   **VPC Flow Logs** allow you to monitor the network traffic to, from, and within your VPC. Logs are stored in CloudWatch Logs groups, and can be used for security monitoring (with third party tools), performance evaluation, and forensic investigation.
     -	See the [VPC Flow Logs User Guide](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) for basic information.
     -	See the [flowlogs-reader](https://github.com/obsrvbl/flowlogs-reader) CLI tool and Python library to retrieve and work with VPC Flow Logs.
-    -	Services like [Observable Networks](https://observable.net/) and [Sumo Logic](https://www.sumologic.com/) can use VPC Flow Logs as input for security monitoring and/or searching.
 
 ### VPC and Network Security Gotchas and Limitations
 

--- a/README.md
+++ b/README.md
@@ -1109,6 +1109,7 @@ VPCs, Network Security, and Security Groups
 -   **VPC Flow Logs** allow you to monitor the network traffic to, from, and within your VPC. Logs are stored in CloudWatch Logs groups, and can be used for security monitoring (with 3rd party tools), performance evaluation, and forensic investigation.
     -	See the [VPC Flow Logs User Guide](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/flow-logs.html) for basic information.
     -	See the [flowlogs-reader](https://github.com/obsrvbl/flowlogs-reader) CLI tool and Python library to retrieve and work with VPC Flow Logs.
+    -	Services like [Observable Networks](https://observable.net/) and [Sumo Logic](https://www.sumologic.com/) can use VPC Flow Logs as input for security monitoring and/or searching.
 
 ### VPC and Network Security Gotchas and Limitations
 


### PR DESCRIPTION
This PR adds a note about monitoring VPC activity with VPC Flow Logs. It links to the official documentation, to an open source command line tool / library for reading the data, and to services that can make use of the data.

__Disclosure__: The CLI tool is sponsored by my employer, [Observable Networks](http://observable.net/), which operates a network security monitoring service that uses VPC Flow Logs.