### PR TITLE
Added ALB Gotcha about unhealthy targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ ALB
 -	ALBs do not (yet) support routing based on HTTP “Host” header or HTTP verb.
 -	Instances in the ALB's target groups have to either have a single, fixed healthcheck port (“EC2 instance”-level healthcheck) or the healthcheck port for a target has to be the same as its application port (“Application instance”-level healthcheck) - you can't configure a per-target healthcheck port that is different than the application port.
 -	ALBs are VPC-only (they are not available in EC2 Classic)
+-	In a target group, if there is no healthy target, all requests are routed to all targets. An example: you add a target group containing a single service (with a long init phase maybe) as target to a listener, it does not pass health checks (yet), requests will still reach your (initializing) service. 
 
 Elastic IPs
 -----------


### PR DESCRIPTION
"If no Availability Zone contains a healthy target, the load balancer nodes route requests to all targets."

source: http://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html