### PR TITLE
Update the definition of AWS SWF

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ General Information
 -	**Compound services:** These are similarly specific, but are full-blown services that tackle complex problems and may tie you in. Usefulness depends on your requirements. If you have large or significant need, you may have these already managed by in-house systems and engineering teams.
 	-	[Machine Learning](https://aws.amazon.com/machine-learning/): Machine learning model training and classification
 	-	⛓🕍[Data Pipeline](https://aws.amazon.com/datapipeline/): Managed ETL service
-	-	⛓🕍[SWF](https://aws.amazon.com/swf/): Managed background job workflow
+	-	⛓🕍[SWF](https://aws.amazon.com/swf/): Managed state tracker for distributed polyglot job workflow
 	-	⛓🕍[Lumberyard](https://aws.amazon.com/lumberyard/): 3D game engine
 -	**Mobile/app development:**
 	-	[SNS](https://aws.amazon.com/sns/): Manage app push notifications and other end-user notifications


### PR DESCRIPTION
First, thanks for doing this!

Just a small update regarding SWF: SWF is not only a managed background job workflow (you have to write your own decider and your own tasks). It also stores and tracks states of each activity (defined has “events" in the workflow's "history”), which it sends to the decider and the workers. I added polyglot because at the comparison of other systems like Luigi, SWF is language agnostic. You can write the decider in one language, and write an activity in Go, and another one in python.