### PR TITLE
Add gotcha about Lambda DLQ regional availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,7 @@ Lambda
 -	🔸Managing lots of Lambda functions is a workflow challenge, and tooling to manage Lambda deployments is still immature.
 -	🔸AWS’ official workflow around managing function [versioning and aliases](https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html) is painful.
 -	❗📜 Currently [as of October, 2016](https://github.com/open-guides/og-aws/pull/199/files/c99bddb4ee2437587f1e188d47be2bb1da01f81d#r83529126) Lambda functions can sometimes stop working for 2-3 minutes for failure recovery purposes according to a support ticket answer from Lambda development team. They are working to prevent this in the future.
+-	🔸 At the time of writing (12 December 2016) Death Letter Queues are only available in the Ohio (us-east-2) region.
 
 ### Lambda Code Samples
 

--- a/README.md
+++ b/README.md
@@ -1239,7 +1239,7 @@ Lambda
 -	🔸Managing lots of Lambda functions is a workflow challenge, and tooling to manage Lambda deployments is still immature.
 -	🔸AWS’ official workflow around managing function [versioning and aliases](https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html) is painful.
 -	❗📜 Currently [as of October, 2016](https://github.com/open-guides/og-aws/pull/199/files/c99bddb4ee2437587f1e188d47be2bb1da01f81d#r83529126) Lambda functions can sometimes stop working for 2-3 minutes for failure recovery purposes according to a support ticket answer from Lambda development team. They are working to prevent this in the future.
--	🔸 At the time of writing (12 December 2016) Death Letter Queues are only available in the Ohio (us-east-2) region.
+-	🔸 At the time of writing (12 December 2016) Dead Letter Queues are only available in the Ohio (us-east-2) region.
 
 ### Lambda Code Samples
 


### PR DESCRIPTION
This limitation isn't mentioned in the official docs, but confirmed with a support request.

> [...] this new functionality is only available in the US East (Ohio) region. We are currently working on rolling out this feature to more regions but there is no ETA at this time.
