### PR TITLE
Updated info regarding ALB Host header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,7 +1049,7 @@ ALB
 -	🔸ALBs only support HTTP/2 over HTTPS (no plain-text HTTP/2).
 -	🔸ALBs only support HTTP/2 to external clients and not to internal resources (instances/containers).
 -	ALBs support HTTP routing but not port-based TCP routing.
--	ALBs do not (yet) support routing based on HTTP “Host” header or HTTP verb.
+-	ALBs support routing based on HTTP “Host” header or HTTP verb
 -	Instances in the ALB’s target groups have to either have a single, fixed healthcheck port (“EC2 instance”-level healthcheck) or the healthcheck port for a target has to be the same as its application port (“Application instance”-level healthcheck) - you can't configure a per-target healthcheck port that is different than the application port.
 -	ALBs are VPC-only (they are not available in EC2 Classic)
 -	In a target group, if there is no healthy target, all requests are routed to all targets. For example, if you point a listener at a target group containing a single service that has a long initialization phase (during which the health checks would fail), requests will reach the service while it is still starting up.


### PR DESCRIPTION
Support for Host based routing was [announced](https://aws.amazon.com/about-aws/whats-new/2017/04/elastic-load-balancing-adds-support-for-host-based-routing-and-increased-rules-on-its-application-load-balancer/) some time ago.