### PR TITLE
Configure travis CI to check links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: ruby
+rvm: 2.2
+before_script: gem install awesome_bot
+script: awesome_bot README.md --allow-redirect --allow-dupe --allow 429 -w .amazonaws.com


### PR DESCRIPTION
This utilises Travis CI to run the awesome_bot
ruby gem to check links in the README file. Preventing
broken links from making it into the project.

https://github.com/dkhamsing/awesome_bot

Guide to configuring Travis https://docs.travis-ci.com/user/getting-started/