### PR TITLE
Added region specificity gotcha for KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1551,6 +1551,7 @@ KMS
 -	🔸The Encrypt API only works with < 4KB of data. Larger data requires generating and managing a [data key](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys) in your application layer.
 -	🔸KMS audit events are not available in the [CloudTrail Lookup Events API](http://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_LookupEvents.html). You need to look find them in the raw .json.gz files that CloudTrail saves in S3.
 -	🔸In order to encrypt a multi-part upload to S3, the KMS Key Policy needs to allow “kms:Decrypt” and “kms:GenerateDataKey*” in addition to “kms:Encrypt”, otherwise the upload will fail with an “AccessDenied” error.
+-	🔸KMS Keys are region specific - keys are stored and can be used only in the region they are created, and cannot be transferred to other regions.
 
 CloudFront
 ----------

--- a/README.md
+++ b/README.md
@@ -1551,7 +1551,7 @@ KMS
 -	🔸The Encrypt API only works with < 4KB of data. Larger data requires generating and managing a [data key](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys) in your application layer.
 -	🔸KMS audit events are not available in the [CloudTrail Lookup Events API](http://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_LookupEvents.html). You need to look find them in the raw .json.gz files that CloudTrail saves in S3.
 -	🔸In order to encrypt a multi-part upload to S3, the KMS Key Policy needs to allow “kms:Decrypt” and “kms:GenerateDataKey*” in addition to “kms:Encrypt”, otherwise the upload will fail with an “AccessDenied” error.
--	🔸KMS Keys are region specific - they are stored, and can only be used in the region they are created. The keys cannot be transferred to other regions.
+-	🔸KMS keys are region specific — they are stored and can only be used in the region in which they are created. They can't be transferred to other regions.
 
 CloudFront
 ----------

--- a/README.md
+++ b/README.md
@@ -1551,7 +1551,7 @@ KMS
 -	🔸The Encrypt API only works with < 4KB of data. Larger data requires generating and managing a [data key](http://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#data-keys) in your application layer.
 -	🔸KMS audit events are not available in the [CloudTrail Lookup Events API](http://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_LookupEvents.html). You need to look find them in the raw .json.gz files that CloudTrail saves in S3.
 -	🔸In order to encrypt a multi-part upload to S3, the KMS Key Policy needs to allow “kms:Decrypt” and “kms:GenerateDataKey*” in addition to “kms:Encrypt”, otherwise the upload will fail with an “AccessDenied” error.
--	🔸KMS Keys are region specific - keys are stored and can be used only in the region they are created, and cannot be transferred to other regions.
+-	🔸KMS Keys are region specific - they are stored, and can only be used in the region they are created. The keys cannot be transferred to other regions.
 
 CloudFront
 ----------


### PR DESCRIPTION
This is something that can be overlooked unless the key ARNs are observed, but most developers only deal with key IDs. The FAQs for KMS do cover it.