### PR TITLE
Added the SSE-SQS <-> SNS gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -2008,7 +2008,7 @@ SNS
 ### SNS Gotchas and Limitations
 
 - 🔸 HTTP/S subscribers of SNS topics need to have public endpoints, as SNS does not support calling private endpoints (like those in a private subnet within a VPC).
-
+- 🔸 In a fan-out scenario, [SSE-enabled SQS](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html) subscribers of an SNS topic [will not receive](https://lobster1234.github.io/2017/10/14/fan-out-with-sns-and-sqs-gotcha/) the messages sent to the topic.
 
 High Availability
 -----------------


### PR DESCRIPTION
I wrote a blog demo-ing this gotcha - https://lobster1234.github.io/2017/10/14/fan-out-with-sns-and-sqs-gotcha/.

Could not find it documented anywhere in the official docs per my extensive search, but this one bit us hard during a production rollout as we use SSE SQS in prod but not in lower environments.