### PR TITLE
Add note on API Gateway query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,6 +1450,8 @@ API Gateway
 -	🔸Many changes to API Gateway resources need to be 'deployed' via console or API call. Unfortunately, API Gateway is terrible about notifying the user when changes are staged for deployment and what changes require deployment. If you've changed something about your API and it's not taking effect, there's a decent chance you just need to deploy it.
 	-	In particular, when deploying an API Gateway as part of a CloudFormation stack, changes will not automatically deploy unless the deployment resource itself was changed. You can change work around this by always changing the deployment resource on a CloudFormation update, or running a custom resource that ensures the deployment is made.
 	-	Alternatively, by using the [Serverless Application Model](https://github.com/awslabs/serverless-application-model) definition for an API Gateway resource, you can always expect the API to be deployed on a stack update since SAM will generate a new deployment every time.
+- 🔸API Gateway does not support nested query parameters on method requests. 
+
 
 🚧 [*Please help expand this incomplete section.*](CONTRIBUTING.md)
 


### PR DESCRIPTION
API gateway does not have full support for nested query parameters. Based on personal experience and their [docs](https://docs.aws.amazon.com/apigateway/api-reference/making-http-requests/ ). See the *HTTP request query parameters* section