### PR TITLE
Added general reference: AWS cloud cost checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2263,6 +2263,7 @@ This section covers a few unusually useful or “must know about” resources or
 	-	[AWS documentation as Kindle ebooks](https://www.amazon.com/Amazon-Web-Services/e/B007R6MVQ6)
 -	General references
 	-	[AWS Well Architected Framework Guide](https://d0.awsstatic.com/whitepapers/architecture/AWS_Well-Architected_Framework.pdf): Amazon’s own 56 page guide to operational excellence - guidelines and checklists to validate baseline security, reliability, performance (including high availability) and cost optimization practices.
+	-       [Lower AWS Cloud Costs Checklist](https://www.powerdown.io/blog/posts/stories/checklist-to-lower-aws-cloud-costs.html)
 	-	[Awesome Microservices](https://github.com/mfornos/awesome-microservices): A curated list of tools and technologies for microservice architectures. Worth browsing to learn about popular open source projects.
 	-	[Is it fast yet?](https://istlsfastyet.com/): Ilya Grigorik’s TLS performance overview
 	-	[High Performance Browser Networking](https://hpbn.co/): A full, modern book on web network performance; a presentation on the HTTP/2 portion is [here](https://docs.google.com/presentation/d/1r7QXGYOLCh4fcUq0jDdDwKJWNqWK1o4xMtYpKZCJYjM/edit?usp=sharing).


### PR DESCRIPTION
Added to general references a checklist document to help with lowering AWS cloud costs.

[Lower AWS Cloud Costs Checklist](https://www.powerdown.io/blog/posts/stories/checklist-to-lower-aws-cloud-costs.html)

Disclosure: I authored the checklist and work for PowerDown that is briefly mentioned in the paper.