### PR TITLE
Whitelist swagger.io due to bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm: 2.2
 before_script: gem install awesome_bot
-script: awesome_bot README.md --allow-redirect --allow-dupe --allow 429 -w .amazonaws.com,news.ycombinator.com 
+script: awesome_bot README.md --allow-redirect --allow-dupe --allow 429 -w .amazonaws.com,news.ycombinator.com,swagger.io


### PR DESCRIPTION
There's a known issue in awesome_bot; whitelisting swagger.io to
silence the warning pending upstream fix.