### PR TITLE
Specify Aurora release in the gotchas and add a line about GTID lack of support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1235,7 +1235,9 @@ RDS Aurora
 
 ### RDS Aurora Gotchas and Limitations
 
--	🔸[Aurora is based on MySQL 5.6.10](https://news.ycombinator.com/item?id=12415693) with some cherry-picking of later MySQL features. It is missing most 5.7 features as well as some online DDL features introduced in 5.6.17.
+-	🔸[Aurora 1.x is based on MySQL 5.6.x](https://news.ycombinator.com/item?id=12415693) with some cherry-picking of later MySQL features. It is missing most 5.7 features as well as some online DDL features introduced in 5.6.17.
+- Aurora does not support GTID transactions even in the 5.6/Aurora 1.x release line.
+- Aurora maximum cluster size is 64 TB
 
 RDS SQL Server
 --------------

--- a/README.md
+++ b/README.md
@@ -1235,7 +1235,7 @@ RDS Aurora
 
 ### RDS Aurora Gotchas and Limitations
 
--	🔸[Aurora 1.x is based on MySQL 5.6.x](https://news.ycombinator.com/item?id=12415693) with some cherry-picking of later MySQL features. It is missing most 5.7 features as well as some online DDL features introduced in 5.6.17.
+- 🔸[Aurora 1.x is based on MySQL 5.6.x](https://news.ycombinator.com/item?id=12415693) with some cherry-picking of later MySQL features. It is missing most 5.7 features as well as some online DDL features introduced in 5.6.17.
 - Aurora does not support GTID transactions even in the 5.6/Aurora 1.x release line.
 - Aurora maximum cluster size is 64 TB
 


### PR DESCRIPTION
* Aurora 1.x is based on 5.6..now that 2.0 is out and based on 5.7 the distinction needs to be clear
* GTID is a 5.6 feature but is not supported in any Aurora releases.
* A note on the maximum sized instance Aurora allows