### PR TITLE
Fix Batch TOC link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2183,6 +2183,7 @@ OpsWorks
   - Paris
   - Seoul
   - Mumbai
+
 Batch
 -------------------
 


### PR DESCRIPTION
The header was not being picked up without a leading empty line.