### PR TITLE
Fargate for EKS has not launched yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1514,7 +1514,7 @@ Fargate
 
 ### Fargate Gotchas and Limitations
 -   As of April 2018, Fargate is available in [multiple regions](https://aws.amazon.com/about-aws/whats-new/2018/04/aws-fargate-now-available-in-ohio--oregon--and-ireland-regions/): us-east-1, us-east-2, us-west-2, and eu-west-1
--   As of January 2018, Fargate can only be used with ECS, however there are plans to support EKS later in 2018
+-   As of January 2019, Fargate can only be used with ECS. Support for EKS [was originally planned for 2018](https://aws.amazon.com/blogs/aws/aws-fargate/), but has yet to launch.
 -   The smallest resource values that can be configured for an ECS Task that uses Fargate is 0.25 vCPU and 0.5 GB of memory
 
 


### PR DESCRIPTION
I love AWS, but I want to throw some shade here. This is probably the reason that they don't give launch estimates very often, because it is usually not very accurate. So we should be happy that this is the exception rather than the rule. :)

- https://www.youtube.com/watch?v=1IxDLeFQKPk&t=30m30s
  - _Available for EKS in 2018_

![screen shot](https://user-images.githubusercontent.com/1991151/50624267-34e7b700-0ed3-11e9-98c9-db3d9eaeb5a2.jpg)


I was also generally annoyed by the lack of punctuation in the Fargate section. Should I feel free to add some periods there?

In `CONTRIBUTING.md`, can we add a **Typographical convention** saying "End sentences with a period."? :)