### PR TITLE
Fix formatting of specialty certification entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,9 +467,9 @@ Learning and Career Development
   -	[Certified SysOps Administrator Associate](https://aws.amazon.com/certification/certified-sysops-admin-associate/)
   -	[Certified Solutions Architect Professional](https://aws.amazon.com/certification/certified-solutions-architect-professional/)
   -	[Certified DevOps Engineer Professional](https://aws.amazon.com/certification/certified-devops-engineer-professional/)
-  -     [Certified Security – Specialty](https://aws.amazon.com/certification/certified-security-specialty/)
-  -     [Certified Big Data – Specialty](https://aws.amazon.com/certification/certified-big-data-specialty/)
-  -     [Certified Advanced Networking – Specialty](https://aws.amazon.com/certification/certified-advanced-networking-specialty/)
+  - [Certified Security – Specialty](https://aws.amazon.com/certification/certified-security-specialty/)
+  - [Certified Big Data – Specialty](https://aws.amazon.com/certification/certified-big-data-specialty/)
+  - [Certified Advanced Networking – Specialty](https://aws.amazon.com/certification/certified-advanced-networking-specialty/)
 
 -	**Getting certified:** If you’re interested in studying for and getting certifications, [this practical overview](https://gist.github.com/leonardofed/bbf6459ad154ad5215d354f3825435dc) tells you a lot of what you need to know. The official page is [here](https://aws.amazon.com/training/) and there is an [FAQ](https://aws.amazon.com/certification/faqs/).
 -	**Do you need a certification?** Especially in consulting companies or when working in key tech roles in large non-tech companies, certifications are important credentials. In others, including in many tech companies and startups, certifications are not common or considered necessary. (In fact, fairly or not, some Silicon Valley hiring managers and engineers see them as a “negative” signal on a resume.)


### PR DESCRIPTION
Due to excess whitespace, the entries weren't displayed as links.