### PR TITLE
Add info about Step Function execution limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1649,6 +1649,7 @@ Step Functions
 ### Step Functions Gotchas and Limitations
 -   Step Functions are free tier eligible up to an initial 4000 transitions per month. Thereafter, the charge is $0.025 per 1000 state transitions.
 -   You can have many, simultaneous, executions, but be aware of lambda throttling limits. This has been per-account, pre-region, but recently became settable per-lambda.
+-   Step Function executions are limited to 25,000 events. Each step creates multiple events. This means that [iterating a loop using Lambda](https://docs.aws.amazon.com/step-functions/latest/dg/tutorial-create-iterate-pattern-section.html) is limited to an iteration count of around 3000 before needing to [continue as a new execution](https://docs.aws.amazon.com/step-functions/latest/dg/tutorial-continue-new.html).
 
 Route 53
 --------


### PR DESCRIPTION
This limit is not clearly documented and reduces the range of situations that it's appropriate to use Step Functions for iteration.