### PR TITLE
Update README.md: API Gateway limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1624,7 +1624,7 @@ API Gateway
 	-	Alternatively, by using the [Serverless Application Model](https://github.com/awslabs/serverless-application-model) definition for an API Gateway resource, you can always expect the API to be deployed on a stack update since SAM will generate a new deployment every time.
 - 🔸API Gateway does not support nested query parameters on method requests.
 - 🔸API Gateway limits number of resources to 300, as described [here](http://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-limits). This is something to be considered when you start using API Gateway as a platform where your team/organization deploys to the same API Gateway.
-- 🔸API Gateway can only reach backend services through the use of AWS PrivateLink using an NLB service endpoint. This causes issues with basic public-to-private resource routing and does not scale.
+- 🔸API Gateway can only reach backend services through the use of AWS PrivateLink using an NLB service endpoint. This causes issues with basic public-to-private resource routing, for instance when hosting a REST-service behind an Application Load Balancer you are not able to route API calls to the ALB directly, it must be fronted by an NLB. The same applies to all other internal VPC resources.
 
 🚧 [*Please help expand this incomplete section.*](CONTRIBUTING.md)
 

--- a/README.md
+++ b/README.md
@@ -1624,6 +1624,7 @@ API Gateway
 	-	Alternatively, by using the [Serverless Application Model](https://github.com/awslabs/serverless-application-model) definition for an API Gateway resource, you can always expect the API to be deployed on a stack update since SAM will generate a new deployment every time.
 - 🔸API Gateway does not support nested query parameters on method requests.
 - 🔸API Gateway limits number of resources to 300, as described [here](http://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html#api-gateway-limits). This is something to be considered when you start using API Gateway as a platform where your team/organization deploys to the same API Gateway.
+- 🔸API Gateway can only reach backend services through the use of AWS PrivateLink using an NLB service endpoint. This causes issues with basic public-to-private resource routing and does not scale.
 
 🚧 [*Please help expand this incomplete section.*](CONTRIBUTING.md)
 


### PR DESCRIPTION
Limitations to what resources API Gateway can reach within a VPC.

For instance, you are unable to do basic proxying from a regional, edge-optimized or private API Gateway endpoint to a web service hosted within a VPC without an NLB deployed and placed upstream of that service. There are several problems with this, namely, you are forced to use an NLB, instead of an ELB or an ALB which are L7 load-balancers.

You also cannot proxy to a web service hosted on an EC2 instance that is in a private subnet. The EC2 instance has to be publicly accessible.