### PR TITLE
Update link to ElastiCache User Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1362,7 +1362,8 @@ ElastiCache
 ### ElastiCache Basics
 
 - 📒 [Homepage](https://aws.amazon.com/elasticache/) ∙ [User
-  guide](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide) ∙
+  guide for Redis](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/index.html) ∙ [User
+  guide for Memcached](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/index.html) ∙
   [FAQ](https://aws.amazon.com/elasticache/faqs/) ∙
   [Pricing](https://aws.amazon.com/elasticache/pricing/)
 - **ElastiCache** is a managed in-memory cache service, that can be used to


### PR DESCRIPTION
Replaces broken link with two URLs to separate user guides for Redis and
Memcached.