### PR TITLE
Update Terraform link in CloudFormation alternatives section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1800,8 +1800,7 @@ CloudFormation
 [Back to top :arrow_up:](#table-of-contents)
 ### CloudFormation Alternatives and Lock-In
 
--	HashiCorp’s [Terraform](https://www.
-/intro/vs/cloudformation.html) is a third-party alternative that can support other cloud platforms/providers including [Azure](https://registry.terraform.io/providers/hashicorp/azurerm/latest) and [OpenStack](https://www.terraform.io/docs/providers/openstack/).
+-	HashiCorp’s [Terraform](https://www.terraform.io/intro/vs/cloudformation.html) is a third-party alternative that can support other cloud platforms/providers including [Azure](https://registry.terraform.io/providers/hashicorp/azurerm/latest) and [OpenStack](https://www.terraform.io/docs/providers/openstack/).
 - 🔸Some AWS features may not be available in Terraform (e.g. multi-AZ ElastiCache using Redis), and you may have to resort to embedded CloudFormation templates.
 -	[Pulumi](https://www.pulumi.com/) enables teams to define and deliver Cloud Native Infrastructure as Code on any cloud, with any language. From containers to serverless to Kubernetes to infrastructure.
 


### PR DESCRIPTION
## Issue
- The Terraform URL in the CloudFormation alternatives section is no longer a valid URL.

## Resolution
- Update the markdown link to include the correct URL.