### PR TITLE
Fargate: Remove obsolete limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1612,8 +1612,6 @@ Fargate
 
 [Back to top :arrow_up:](#table-of-contents)
 ### Fargate Gotchas and Limitations
--   As of April 2018, Fargate is available in [multiple regions](https://aws.amazon.com/about-aws/whats-new/2018/04/aws-fargate-now-available-in-ohio--oregon--and-ireland-regions/): us-east-1, us-east-2, us-west-2, and eu-west-1
--   As of January 2019, Fargate can only be used with ECS. Support for EKS [was originally planned for 2018](https://aws.amazon.com/blogs/aws/aws-fargate/), but has yet to launch.
 -   The smallest resource values that can be configured for an ECS Task that uses Fargate is 0.25 vCPU and 0.5 GB of memory
 -   [Task storage is ephemeral. After a Fargate task stops, the storage is deleted.](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html)
 


### PR DESCRIPTION
Great guide. Thank you so much for taking the time writing it. ⭐
While reading through some sections I noticed two Fargate limitations that I would consider obsolete.

Fargate service availability has expanded and it is now [available in 25 regions](https://docs.aws.amazon.com/AmazonECS/latest/userguide/what-is-fargate.html). 

Also, it seems Fargate [can now be used with EKS as well](https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html). Haven't used it myself hence my reservation.

So I'd suggest removing those two points from the limitations section.
Please let me know if I am missing something or anything needs changed for you to include this PR.