### PR TITLE
Update ECS links to hosted Kubernetes solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1548,7 +1548,7 @@ ECS
 [Back to top :arrow_up:](#table-of-contents)
 ### ECS Alternatives and Lock-in
 
--	[Kubernetes](https://kubernetes.io): Extensive container platform. Available as a hosted solution on Google Cloud (https://cloud.google.com/container-engine/) and AWS (https://tectonic.com/). AWS has a Kubernetes Quickstart (https://aws.amazon.com/quickstart/architecture/heptio-kubernetes/) developed in collaboration with Heptio.
+-	[Kubernetes](https://kubernetes.io): Extensive container platform. Available as a hosted solution on [Google Cloud](https://cloud.google.com/kubernetes-engine), [AWS](https://aws.amazon.com/eks/), [Azure](https://azure.microsoft.com/en-us/services/kubernetes-service/), [DigitalOcean](https://www.digitalocean.com/products/kubernetes/), and [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift).
 -	[Nomad](https://www.nomadproject.io/): Orchestrator/Scheduler, tightly integrated in the HashiCorp stack (Consul, Vault, etc).
 
 🚧 [*Please help expand this incomplete section.*](CONTRIBUTING.md)


### PR DESCRIPTION
Made the following updates:

* Google's offering is now called Google Kubernetes Engine and has a new URL
* AWS has a Kubernetes offering, EKS, already described in this document, so the Heptio reference implementation need not be listed with the other hosted solutions
* Azure, DigitalOcean, and OpenShift are already listed as alternatives in the EKS section and should be included here as well

Disclosure: I work for AWS.