### PR TITLE
Fix link to Rackspace AWS guide (PDF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ We cover security basics first, since configuring user accounts is something you
 -	Assign IAM roles by realm — for example, to development, staging, and production. If you’re setting up a role, it should be tied to a specific realm so you have clean separation. This prevents, for example, a development instance from connecting to a production database.
 -	**Best practices:** AWS’ [list of best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) is worth reading in full up front.
 -	**IAM Reference:** [This interactive reference for all IAM actions, effects, and resources](https://iam.cloudonaut.io/) is great to have open while writing new or trying to understand existing IAM policies.
--	**Multiple accounts:** Decide on whether you want to use multiple AWS accounts and [research](https://dab35129f0361dca3159-2fe04d8054667ffada6c4002813eccf0.ssl.cf1.rackcdn.com/downloads/pdfs/Rackspace%20Best%20Practices%20for%20AWS%20-%20Identity%20Managment%20-%20Billing%20-%20Auditing.pdf) how to organize access across them. Factors to consider:
+-	**Multiple accounts:** Decide on whether you want to use multiple AWS accounts and [research](https://manage.rackspace.com/aws/docs/product-guide/pdfs/fanatical_support_for_aws_product_guide_2020-04-29-14:29.pdf) how to organize access across them. Factors to consider:
 	-	Number of users
 	-	Importance of isolation
 		-	Resource Limits


### PR DESCRIPTION
`Rackspace Best Practices for AWS - Identity Managment - Billing - Auditing.pdf` is no longer available, but `fanatical_support_for_aws_product_guide_2020-04-29-14:29.pdf` seems to cover the same topics.

I don't have the original/missing PDF, so please verify.