### PR TITLE
fix: Corrects spacing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Before using the guide, please read the [**license**](#license) and [**disclaime
 
 [![Slack Chat](https://img.shields.io/badge/Chat-Slack-ff69b4.svg "Join us. Anyone is welcome!")](http://slackhatesthe.cloud)
 
-Please help by [**joining the Slack channel**](http://slackhatesthe.cloud)(we like to talk about AWS in general, even if you only have questions — discussion helps the community and guides improvements) and [**contributing to the guide**](CONTRIBUTING.md). This guide is *open to contributions*, so unlike a blog, it can keep improving. Like any open source effort, we combine efforts but also review to ensure high quality.
+Please help by [**joining the Slack channel**](http://slackhatesthe.cloud) (we like to talk about AWS in general, even if you only have questions — discussion helps the community and guides improvements) and [**contributing to the guide**](CONTRIBUTING.md). This guide is *open to contributions*, so unlike a blog, it can keep improving. Like any open source effort, we combine efforts but also review to ensure high quality.
 
 Scope
 -----


### PR DESCRIPTION
Changed `Slack channel(...` to `Slack channel (...`