### PR TITLE
fix: Rename custom authorizer to Lambda authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1716,7 +1716,7 @@ API Gateway
 	-	Note that if your request or response are too large, CloudWatch will truncate the log. For full request/reply logging, make sure to do so in your integration (e.g. Lambda).
 	-	A good practice when calling API Gateway APIs is to log the request ID on the client. You can later refer to these request IDs in CloudWatch for easier tracing and debugging.
 -	There are multiple ways to secure your API, including built-in support for [AWS Cognito](http://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html). For most use-cases, Cognito is the easiest and simplest way to authenticate users.
-	-	Although you can roll your own solution using a [custom authorizer](http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html), which is basically a Lambda you define that determines if a request is acceptable or not.
+	-	Although you can roll your own solution using a [Lambda authorizer](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html), which is basically a Lambda you define that determines if a request is acceptable or not.
 -	While API Gateway lends itself well to REST-style development, it's perfectly reasonable to implement an RPC-style API in API Gateway as well. Depending on your use-case, this can often lead to a much simpler API structure and smoother client experience.
 	-	RPC-style APIs are particularly useful when designing services that sit deeper in the stack and don't serve content directly to users.
 


### PR DESCRIPTION
AWS renamed customer authorizer to Lambda authorizer, as per docs.
[Previous link](http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html) routes to welcome page now.