### PR TITLE
Add "Fundamentals of DevOps and Software Delivery" to books

### DIFF
--- a/README.md
+++ b/README.md
@@ -2623,6 +2623,7 @@ This section covers a few unusually useful or “must know about” resources or
 	-	[Python and AWS Cookbook](http://shop.oreilly.com/product/0636920020202.do)
 	-	[Resilience and Reliability on AWS](http://shop.oreilly.com/product/0636920026839.do)
 	-	[AWS documentation as Kindle ebooks](https://www.amazon.com/Amazon-Web-Services/e/B007R6MVQ6)
+    -	[Fundamentals of DevOps and Software Delivery](https://www.fundamentals-of-devops.com/)
 -	General references
 	-	[AWS Well Architected Framework Guide](https://d0.awsstatic.com/whitepapers/architecture/AWS_Well-Architected_Framework.pdf): Amazon’s own 56 page guide to operational excellence - guidelines and checklists to validate baseline security, reliability, performance (including high availability) and cost optimization practices.
 	-	[Awesome Microservices](https://github.com/mfornos/awesome-microservices): A curated list of tools and technologies for microservice architectures. Worth browsing to learn about popular open source projects.


### PR DESCRIPTION
Thank you for putting together this lovely guide on AWS! I wish it existed when I first started with AWS ~15 years ago, would've made my life so much easier 😄 

This PR adds _[Fundamentals of DevOps and Software Delivery](https://www.fundamentals-of-devops.com/)_ to the list of books. Disclaimer: I'm the author of this book. I believe it's a good fit here because this book is (a) a guide to all major topics in software delivery and (b) uses AWS for most of the dozens of code examples. In other words, this book is essentially a thorough, hands-on guide to using AWS, including:

- Managing infrastructure as code (with examples of using Bash, Ansible, Packer, and Terraform/OpenTofu to deploy EC2 instances).
- Managing apps using orchestration tools (with examples of how to use EC2, ASGs, ALBs, EKS, and Lambda).
- Building and deploying apps via a CI / CD pipeline (with examples of using GitHub Actions and OIDC to deploy into AWS).
- Working with multiple environments (with examples of using multiple AWS accounts).
- Configuring networking (with examples of setting up VPCs and registering domains in Route 53).
- Managing secrets (with examples of using AWS Secrets Manager).
- Storing data (with examples of using RDS and S3).
- Monitoring your systems (with examples of using CloudWatch).

You can find the full list of examples in https://github.com/brikis98/devops-book.

Please let me know if I should add any additional context to the PR. Thanks!